### PR TITLE
Adición de custom_email, como campo oficial de email.

### DIFF
--- a/eventos/models.py
+++ b/eventos/models.py
@@ -15,10 +15,10 @@ class Evento(models.Model):
     ESTADO_VALS = (FINALIZADO,SIN_INICIAR,CANCELADO)
     ESTADO_NAMES = (_('Finalizado'), _('Sin iniciar'), _('Cancelado'))
     ESTADO_TYPES=   tuple(zip(ESTADO_VALS, ESTADO_NAMES))
-    nombre = models.CharField(_('Name alv'), max_length=50, null=False )
-    descripcion = models.TextField(_('Descirpcion'))
+    nombre = models.CharField(_('Nombre'), max_length=50, null=False )
+    descripcion = models.TextField(_('Descripción'))
     fechaInicio = models.DateTimeField(_('Fecha inicio'), auto_now=False, auto_now_add=False, null=False, validators=[validators.validate_date_start_event_before_now])
-    fechaFinalizacion = models.DateTimeField(_('Fecha finalizacion'), auto_now=False, auto_now_add=False, null=False) 
+    fechaFinalizacion = models.DateTimeField(_('Fecha finalización'), auto_now=False, auto_now_add=False, null=False) 
     estado = models.CharField(max_length=2, choices=ESTADO_TYPES,default=SIN_INICIAR)
     usuariosPreinscritos = models.ManyToManyField(
                                      Usuario,

--- a/usuarios/models.py
+++ b/usuarios/models.py
@@ -2,9 +2,11 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import User, AbstractUser
+from django.contrib.auth.base_user import AbstractBaseUser, BaseUserManager
 from django.contrib.auth.validators import ASCIIUsernameValidator
-
+from django.utils.translation import ugettext as _
 
 # Create your models here.
 
@@ -25,4 +27,5 @@ class Usuario(User):
     rol = models.CharField(max_length=2,choices=ROLES,null=False)
     estadoHabilitado = models.BooleanField(default=True, null=False)
     fechaHoraRegistro = models.DateField(auto_now_add=True, null=False)
-
+    custom_email = models.EmailField(_('Correo electrónico'),max_length=255, unique=True, null=False)
+ 

--- a/usuarios/serializers.py
+++ b/usuarios/serializers.py
@@ -10,7 +10,7 @@ class UsuarioSerializer(serializers.ModelSerializer):
         model = Usuario
         fields = (
             'username', 'password', 'nombres', 'apellidos',
-            'imagenPerfil', 'rol', 'email', 'estadoHabilitado',
+            'imagenPerfil', 'rol', 'custom_email', 'estadoHabilitado',
             'groups', 'fechaHoraRegistro'
             )
         ordering = ['-id']

--- a/www_backend/settings.py
+++ b/www_backend/settings.py
@@ -41,7 +41,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework.authtoken',
-    'imagenes',
+    'imagenes'
     #'django_extensions',
 ]
 


### PR DESCRIPTION
Soluciona el problema del correo nulo sin recurrir a la redefinición del método de autenticación del framework.